### PR TITLE
Allowed to pass strings to setBackgroundColor as well as Color objects

### DIFF
--- a/src/Bitverse/Identicon/Generator/BaseGenerator.php
+++ b/src/Bitverse/Identicon/Generator/BaseGenerator.php
@@ -4,6 +4,10 @@ namespace Bitverse\Identicon\Generator;
 
 use Bitverse\Identicon\Color\Color;
 
+/**
+ * @todo A color factory should be injected allowing to pass
+ *       strings to setBackgroundColor
+ */
 abstract class BaseGenerator implements GeneratorInterface
 {
     /**
@@ -14,9 +18,14 @@ abstract class BaseGenerator implements GeneratorInterface
     /**
      * {@inheritDoc}
      */
-    public function setBackgroundColor(Color $color)
+    public function setBackgroundColor($color)
     {
-        $this->backgroundColor = $color;
+        if ($color instanceof Color) {
+            $this->backgroundColor = $color;
+            return;
+        }
+
+        $this->backgroundColor = Color::parseHex($color);
     }
 
     /**

--- a/src/Bitverse/Identicon/Generator/GeneratorInterface.php
+++ b/src/Bitverse/Identicon/Generator/GeneratorInterface.php
@@ -9,9 +9,9 @@ interface GeneratorInterface
     /**
      * Sets the background color for the generated icons.
      *
-     * @param Color $color
+     * @param Color|string $color
      */
-    public function setBackgroundColor(Color $color);
+    public function setBackgroundColor($color);
 
     /**
      * Generates a unique icon


### PR DESCRIPTION
Hotfix which allows for passing strings as well as Color objects in GeneratorInterface::setBackgroundColor().

This is a hotfix related to an issue with symfony being unable to compile the DIC with a definition's method call passing an object.
